### PR TITLE
refactor: text 컴포넌트 Chakra Text 컴포넌트로 wrapping

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,12 +1,12 @@
-import React, { CSSProperties, PropsWithChildren } from 'react';
-import { css } from '@emotion/react';
-import styled from '@emotion/styled';
-import theme, { FontKeyType, PalleteValueType } from '@styles/theme';
+import { PropsWithChildren } from 'react';
+import {
+  Text as ChakraText,
+  TextProps as ChakraTextProps,
+} from '@chakra-ui/react';
+import theme, { FontKeyType, PalleteValueType, fonts } from '@styles/theme';
 
-interface TextProps extends React.ComponentProps<'div'> {
+interface TextProps extends ChakraTextProps {
   type: FontKeyType;
-  display?: CSSProperties['display'];
-  textAlign?: CSSProperties['textAlign'];
   color?: PalleteValueType;
 }
 
@@ -14,32 +14,19 @@ const Text = ({
   type,
   children,
   display = 'block',
-  textAlign = 'left',
   color = theme.colors.text.general,
   ...restProps
 }: PropsWithChildren<TextProps>) => {
   return (
-    <TextWrapper
-      type={type}
+    <ChakraText
       display={display}
-      textAlign={textAlign}
       color={color}
+      css={fonts[type]}
       {...restProps}
     >
       {children}
-    </TextWrapper>
+    </ChakraText>
   );
 };
-
-const TextWrapper = styled.div<TextProps>`
-  ${(props) => {
-    return css`
-      ${theme.fonts[props.type]};
-      text-align: ${props.textAlign};
-      display: ${props.display};
-      color: ${props.color};
-    `;
-  }}
-`;
 
 export default Text;


### PR DESCRIPTION
## Issue Number

PR: #27 

## Summary

> 구현 내용 및 작업한 내역

- [x] emotion/styled 로 작업된 내용을 Chakra의 Text 컴포넌트로 wrapping 해보았습니다.
- [x] 기본 값인 textAlign 을 삭제했습니다.
- [x] extends type을 Chakra의 TextProps 타입을 extends 받았습니다.

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- https://github.com/mash-up-kr/moit-web/pull/27#discussion_r1237363729 에서 설명한 내용을 구현해봤습니다.
- 영지님이 말씀하신대로, 커스텀할 경우가 많지 않다면 styled-components를 활용해서 css로 직접 만드는 방법도 크게 상관은 없을 것 같지만, 제가 느낀 차크라 Text 컴포넌트의 장점을 가져올 수 있는 방향이라 생각해서 추가해봤습니다.

## ScreenShots

Before

![image](https://github.com/mash-up-kr/moit-web/assets/57122180/e52e0b42-6e63-4276-8013-73316437b0c4)

After

![image](https://github.com/mash-up-kr/moit-web/assets/57122180/1151a15b-c2f0-4978-b34a-6558784b59b7)


## Testscope

> PR 등록 전 확인한 것

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: 로그인 페이지 추가`)
- [x] description에 PR에 대해 구체적으로 설명했는가
